### PR TITLE
Fix: Wrong UTC calculation in stockmanagement utils.

### DIFF
--- a/src/common/utils/stockmanagement/utils.js
+++ b/src/common/utils/stockmanagement/utils.js
@@ -38,7 +38,7 @@ const convertToTimeSeries = period => {
   const year = str_period.substring(0, 4);
 
   // Extract Month
-  const month = str_period.substring(5, 6);
+  const month = str_period.substring(4, 6);
 
   // We subtract - 1 because JS reads months from 0
   // with Jan = 0, Feb = 1 etc.

--- a/src/views/Dashboard/components/StockManagementPanel/index.js
+++ b/src/views/Dashboard/components/StockManagementPanel/index.js
@@ -186,7 +186,7 @@ export function StockManagementPanel() {
   const [
     districtStockLevelsEndMonth,
     setDistrictStockLevelsEndMonth
-  ] = useState("Jun 2019");
+  ] = useState("Dec 2019");
 
   const [
     districtStockLevelsStartMonth,
@@ -202,7 +202,7 @@ export function StockManagementPanel() {
   // -------------------------------------------------------------------------
 
   const [refillRateStartMonth, setRefillRateStartMonth] = useState("Jan 2019");
-  const [refillRateEndMonth, setRefillRateEndMonth] = useState("Jun 2019");
+  const [refillRateEndMonth, setRefillRateEndMonth] = useState("Dec 2019");
   const [refillRateVaccine, setRefillRateVaccine] = useState("PENTA");
   const [refillRateDistrict, setRefillRateDistrict] = useState("Abim District");
   const [refillRateDistrict2, setRefillRateDistrict2] = useState([
@@ -217,7 +217,7 @@ export function StockManagementPanel() {
   // -------------------------------------------------------------------------
 
   const [uptakeRateStartMonth, setUptakeRateStartMonth] = useState("Jan 2019");
-  const [uptakeRateEndMonth, setUptakeRateEndMonth] = useState("Jun 2019");
+  const [uptakeRateEndMonth, setUptakeRateEndMonth] = useState("Dec 2019");
   const [uptakeRateVaccine, setUptakeRateVaccine] = useState("PENTA");
   const [uptakeRateDistrict, setUptakeRateDistrict] = useState("National");
 
@@ -230,7 +230,7 @@ export function StockManagementPanel() {
     setDistrictStockTrendStartMonth
   ] = useState("Jan 2019");
   const [districtStockTrendEndMonth, setDistrictStockTrendEndMonth] = useState(
-    "Jun 2019"
+    "Dec 2019"
   );
   const [districtStockTrendVaccine, setDistrictStockTrendVaccine] = useState(
     "PENTA"


### PR DESCRIPTION
- Fixed an issue where the wrong epoch time stamp was being returned
  for period values.